### PR TITLE
Update documentation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -549,7 +549,7 @@ Now let's go on with the practical part.
 They could try to use the privileged `ServiceAccount` by changing ownership of a privileged Namespace so that they could create Reconciliation resource there and using the privileged SA.
 This is not permitted as they can't patch Namespaces which have not been created by them. Capsule request validation would not pass.
 
-For other protections against threats in this multi-tenancy scenario please see the Capsule [Multi-Tenancy Benchmark](/docs/general/mtb). 
+For other protections against threats in this multi-tenancy scenario please see the Capsule [Multi-Tenancy Benchmark](https://capsule.clastix.io/docs/general/mtb). 
 
 ## References
 - https://fluxcd.io/docs/installation/#multi-tenancy-lockdown

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -370,35 +370,6 @@ this is the required set of resources to setup a Tenant:
     userGroups:
     - system:serviceaccounts:my-tenant
   ```
-- Additional `ClusterRole` with related `ClusterRoleBinding` that allows to `PATCH` requests on Namespaces, besides `CREATE`. Flux kustomize controller will `kubectl-apply` resources:
-
-  ```yaml
-  apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRole
-  metadata:
-    name: capsule-namespace-provisioner-gitops
-  rules:
-  - apiGroups:
-    - ""
-    resources:
-    - namespaces
-    verbs:
-    - patch
-  ---
-  apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRoleBinding
-  metadata:
-    name: capsule-namespace-provisioner-gitops-my-tenant
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: capsule-namespace-provisioner-gitops
-  subjects:
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:serviceaccounts:my-tenant
-  ```
-
 - Additional `ClusterRole` with related `ClusterRoleBinding` that allows the Tenant GitOps Reconciler to impersonate his own `User` (e.g. `system:serviceaccount:my-tenant:gitops-reconciler`):
   ```yaml
   apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This PR updates the documentation as Capsule now provides `patch` privilege over owned `Namespace`s.